### PR TITLE
Refactor graphql client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ So u should start node server before client.
 yarn server:start & yarn client:start
 ```
 
+## Endpoint configs
+
+Each project(Client or Server) has a configuration directory named `.config`, you can update the config files inside the directory to change config of endpoint.
+
 ## 🎯 TroubleShooting
 
 Troubleshooting is process of diagnosing of the source of a problem, here r the problems that may be encountered in the project. If u find anything that's not on record here, u can give us feedback via [Issue](https://github.com/wizardoc/wizard/issues)🐛.

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^7.0.0",
+    "@nestjs/config": "^0.6.3",
     "@nestjs/core": "^7.0.0",
     "@nestjs/platform-express": "^7.0.0",
     "@nestjs/serve-static": "^2.1.4",

--- a/server/src/constants/auth.ts
+++ b/server/src/constants/auth.ts
@@ -1,0 +1,1 @@
+export const AUTH_KEY = 'authentication';

--- a/server/src/constants/index.ts
+++ b/server/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './auth';

--- a/server/src/controllers/user/user-access.controller.ts
+++ b/server/src/controllers/user/user-access.controller.ts
@@ -1,7 +1,7 @@
 import {Body, Controller, Post, Put} from '@nestjs/common';
-import {gql} from 'graphql-request';
+import {gql, GraphQLClient} from 'graphql-request';
 
-import {HTTP} from 'src/services';
+import {GraphQL} from 'src/decorators';
 
 interface RegisterBody {
   displayName: string;
@@ -17,10 +17,8 @@ interface LoginBody {
 
 @Controller('user')
 export class UserAccessController {
-  constructor(private readonly http: HTTP) {}
-
   @Post('register')
-  register(@Body() registerBody: RegisterBody) {
+  register(@Body() registerBody: RegisterBody, @GraphQL() client: GraphQLClient) {
     const query = gql`
       mutation register($userInfo: CreateUserInfo!) {
         createUser(userInfo: $userInfo) {
@@ -33,11 +31,11 @@ export class UserAccessController {
       }
     `;
 
-    return this.http.sendQuery(query, {userInfo: registerBody});
+    return client.request(query, {userInfo: registerBody});
   }
 
   @Put('login')
-  login(@Body() loginBody: LoginBody) {
+  login(@Body() loginBody: LoginBody, @GraphQL() client: GraphQLClient) {
     const query = gql`
       mutation login($username: String!, $password: String!) {
         login(username: $username, password: $password) {
@@ -54,6 +52,6 @@ export class UserAccessController {
       }
     `;
 
-    return this.http.sendQuery(query, loginBody);
+    return client.request(query, loginBody);
   }
 }

--- a/server/src/decorators/auth/index.ts
+++ b/server/src/decorators/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './jwt';

--- a/server/src/decorators/auth/jwt.ts
+++ b/server/src/decorators/auth/jwt.ts
@@ -1,0 +1,10 @@
+import {createParamDecorator, ExecutionContext, CustomDecorator} from '@nestjs/common';
+import {Request} from 'express';
+
+import {AUTH_KEY} from 'src/constants';
+
+export const Jwt = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+  const {headers}: Request = ctx.switchToHttp().getRequest();
+
+  return headers[AUTH_KEY];
+});

--- a/server/src/decorators/graphql/graphql-client.ts
+++ b/server/src/decorators/graphql/graphql-client.ts
@@ -1,0 +1,43 @@
+import {createParamDecorator, ExecutionContext} from '@nestjs/common';
+import {Request} from 'express';
+import {GraphQLClient as GraphQLRequestClient} from 'graphql-request';
+
+import {AUTH_KEY} from 'src/constants';
+
+export interface GraphQLClientRequest extends Request {
+  graphQLEndpoint: string;
+  token: string;
+}
+
+class GraphQLClientFactory {
+  private client: GraphQLRequestClient;
+
+  private constructor(endpoint: string) {
+    this.client = new GraphQLRequestClient(endpoint);
+  }
+
+  private static instance: GraphQLClientFactory | undefined;
+
+  static getClient(endpoint: string): GraphQLRequestClient {
+    const instance =
+      GraphQLClientFactory.instance ??
+      (GraphQLClientFactory.instance = new GraphQLClientFactory(endpoint));
+
+    return instance.client;
+  }
+}
+
+export const GraphQL = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+  const req = ctx.switchToHttp().getRequest<GraphQLClientRequest>();
+  const {graphQLEndpoint, token} = req;
+
+  if (!graphQLEndpoint) {
+    throw new Error('Cannot find endpoint of GraphQL from the request');
+  }
+
+  const client = GraphQLClientFactory.getClient(graphQLEndpoint);
+
+  client.setHeader(AUTH_KEY, token);
+
+  return client;
+});

--- a/server/src/decorators/graphql/index.ts
+++ b/server/src/decorators/graphql/index.ts
@@ -1,0 +1,1 @@
+export * from './graphql-client';

--- a/server/src/decorators/index.ts
+++ b/server/src/decorators/index.ts
@@ -1,0 +1,2 @@
+export * from './auth';
+export * from './graphql';

--- a/server/src/filters/global-error-filter.ts
+++ b/server/src/filters/global-error-filter.ts
@@ -16,9 +16,17 @@ export class GlobalErrorFilter implements ExceptionFilter {
       return;
     }
 
-    const {data, err} = response;
+    // tslint:disable-next-line:no-null-keyword
+    const {data = null, err, error, status} = response;
+    const UnExpectError = {
+      msg: error,
+      status,
+    };
 
     // throw the error that from API server
-    res.send({data, err});
+    res.send({
+      data,
+      err: err ?? UnExpectError,
+    });
   }
 }

--- a/server/src/guards/auth/auth.guard.ts
+++ b/server/src/guards/auth/auth.guard.ts
@@ -1,0 +1,31 @@
+import {CanActivate, ExecutionContext, Injectable} from '@nestjs/common';
+import {isArray} from '@wizardoc/shared';
+
+import {HTTP, AuthService} from 'src/services';
+import {AUTH_KEY} from 'src/constants';
+import {GraphQLClientRequest} from 'src/decorators';
+
+@Injectable()
+export class Auth implements CanActivate {
+  constructor(private http: HTTP, private authService: AuthService) {}
+
+  canActivate(ctx: ExecutionContext): boolean {
+    const req = ctx.switchToHttp().getRequest<GraphQLClientRequest>();
+    const token = req.headers[AUTH_KEY];
+
+    // The token cannot be a array
+    if (isArray(token)) {
+      return false;
+    }
+
+    const hasToken = this.authService.validateToken(token);
+
+    if (!hasToken) {
+      return false;
+    }
+
+    req.token = token;
+
+    return true;
+  }
+}

--- a/server/src/guards/auth/index.ts
+++ b/server/src/guards/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './auth.guard';

--- a/server/src/guards/graphql.guard.ts
+++ b/server/src/guards/graphql.guard.ts
@@ -1,0 +1,19 @@
+import {CanActivate, Injectable, ExecutionContext} from '@nestjs/common';
+
+import {HTTP} from 'src/services';
+import {GraphQLClientRequest} from 'src/decorators';
+
+@Injectable()
+export class GraphQL implements CanActivate {
+  constructor(private http: HTTP) {}
+
+  canActivate(ctx: ExecutionContext): boolean {
+    const req = ctx.switchToHttp().getRequest<GraphQLClientRequest>();
+
+    // Mount endpoint of GraphQL on request object to visit it
+    // by GraphQL client later
+    req.graphQLEndpoint = this.http.graphqlEndpoint;
+
+    return true;
+  }
+}

--- a/server/src/guards/index.ts
+++ b/server/src/guards/index.ts
@@ -1,0 +1,2 @@
+export * from './auth';
+export * from './graphql.guard';

--- a/server/src/modules/user.module.ts
+++ b/server/src/modules/user.module.ts
@@ -1,11 +1,20 @@
 import {Module} from '@nestjs/common';
+import {APP_GUARD} from '@nestjs/core';
 
 import {UserAccessController} from 'src/controllers';
 import {HTTP, HTTPFactory} from 'src/services';
+import {GraphQL} from 'src/guards';
 
 @Module({
   imports: [],
   controllers: [UserAccessController],
-  providers: [HTTPFactory, HTTP],
+  providers: [
+    HTTPFactory,
+    HTTP,
+    {
+      provide: APP_GUARD,
+      useClass: GraphQL,
+    },
+  ],
 })
 export class UserModule {}

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -1,0 +1,12 @@
+import {Injectable} from '@nestjs/common';
+
+@Injectable()
+export class AuthService {
+  // API Server performs specific JWT validation logic
+  validateToken(token: string) {
+    // TODO: just validate the token whether is a JWT or not,
+    // rather than validate using secret
+
+    return !!token;
+  }
+}

--- a/server/src/services/http.service.ts
+++ b/server/src/services/http.service.ts
@@ -9,14 +9,14 @@ import {
 import {Injectable} from '@nestjs/common';
 import {Request, Response} from 'express';
 import {RequestPayloadParser} from '@wizardoc/shared';
-import {request} from 'graphql-request';
 
 import ServerConfig from '../.config/proxy-config.json';
 
 import {ResData, ResError} from './interceptors';
 
-interface Variables {
-  [key: string]: any;
+export interface GraphQLQuery {
+  query: string;
+  variables?: Record<string, any>;
 }
 
 @Injectable()
@@ -41,7 +41,7 @@ export class HTTP extends HTTPService {
     super(httpFactory.getHTTPClientOptions());
   }
 
-  private get graphqlEndpoint() {
+  get graphqlEndpoint() {
     const {addr} = this.httpFactory.getHTTPClientOptions();
 
     return `${addr}${this.GRAPHQL_PATH}`;
@@ -68,11 +68,7 @@ export class HTTP extends HTTPService {
     return result;
   }
 
-  async proxySend(
-    req: Request,
-    res: Response,
-    onData?: OnSuccessCB<any>,
-  ): Promise<void> {
+  async proxySend(req: Request, res: Response, onData?: OnSuccessCB<any>): Promise<void> {
     const parsedOnData = onData ?? ((data: any): any => data);
     const result = await this.proxy(req, res);
 
@@ -86,10 +82,5 @@ export class HTTP extends HTTPService {
         res.send({data: await parsedOnData(result.data.data)});
       }
     }
-  }
-
-  // Query data from graphQL server
-  sendQuery(q: string, variables?: Variables) {
-    return request(this.graphqlEndpoint, q, variables);
   }
 }

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,2 +1,3 @@
-export * from './http-services';
 export * from './interceptors';
+export * from './auth.service';
+export * from './http.service';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,6 +1998,18 @@
     tslib "2.0.3"
     uuid "8.3.2"
 
+"@nestjs/config@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.npm.taobao.org/@nestjs/config/download/@nestjs/config-0.6.3.tgz#ab0c0dccf79696509ced463a888567219c2e5b7d"
+  integrity sha1-qwwNzPeWllCc7UY6iIVnIZwuW30=
+  dependencies:
+    dotenv "8.2.0"
+    dotenv-expand "5.1.0"
+    lodash.get "4.4.2"
+    lodash.has "4.5.2"
+    lodash.set "4.3.2"
+    uuid "8.3.2"
+
 "@nestjs/core@^7.0.0":
   version "7.6.4"
   resolved "https://registry.npmjs.org/@nestjs/core/-/core-7.6.4.tgz#90f9f1aec7bc5abc3b3eb477277c3bd8bdd25d3e"
@@ -5227,6 +5239,16 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-expand@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npm.taobao.org/dotenv-expand/download/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha1-P7rwIL/XlIhAcuomsel5HUWmKfA=
+
+dotenv@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.npm.taobao.org/dotenv/download/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha1-l+YZJZradQ7qPk6j4mvO6lQksWo=
+
 dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
@@ -8442,10 +8464,15 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.get@^4.4.2:
+lodash.get@4.4.2, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.has@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.npm.taobao.org/lodash.has/download/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -8457,7 +8484,7 @@ lodash.memoize@4.x:
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.set@^4.3.2:
+lodash.set@4.3.2, lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=


### PR DESCRIPTION
This PR changes the way to get the client of `graphql-request`. U can use `@GraphQL` to decorate params of the route method to get the client of `graphql-request`, before that u have to inject the `HTTP Service` first, and then read the client through the HTTP Service, but there has a problem that services does not have any context of routes, for instance, u can't read request object in services, but in some condition, API interfaces need to validate the identity of users via validate`Token` from `Header`, but the `node middleware` can't pass the token on headers due to the service cannot read the request object as well as we must use service to invoke graphQL request, that does not make sense.
So I refactor the graphql client which we can read it use decorator, It's due to the `createParamsDecortor` API，in addition, we have a global guard `GraphQL` to pass the`endpoint` through-out the request flow before process the  request, and when we need to pass the token in header, just use `Auth` decorator that pass the `token` through-out the request flow, in other ways, which all do the same thing.